### PR TITLE
Add non-Jekyll repo files to excluded list

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,3 +19,5 @@ github_username:  jekyll
 
 # Build settings
 markdown: kramdown
+
+exclude: [Gemfile, Gemfile.lock, README.md]


### PR DESCRIPTION
Maybe we don’t need to host the Gemfile
