### PR TITLE
Change guidance entries from Jekyll posts to pages

### DIFF
--- a/guidance/get-a-licence-to-export-arms-military-or-dual-use-goods-and-services.markdown
+++ b/guidance/get-a-licence-to-export-arms-military-or-dual-use-goods-and-services.markdown
@@ -2,7 +2,6 @@
 layout: guidance
 title: Get a licence to export arms, military or dual use goods and services
 summary: Summary summary summary summary summary summary summary summary summary summary summary summary.
-date: 2016-02-09 12:45:53 +0000
 permalink: /guidance/get-a-licence-to-export-arms-military-or-dual-use-goods-and-services
 topic:
   name: Exporting and doing business abroad


### PR DESCRIPTION
As we don’t use the date attribute in the URL, we can just use Jekyll pages instead of posts, allowing us to do away with the date value in the front matter that need to match the prefix of the file name and the _posts sub-directory in the folder.
