### PR TITLE
Update banner style to be prototype specific

### DIFF
--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,5 +1,5 @@
-<header role='banner' id='prototype-banner'>
-  <div id='wrapper'>
+<header id='prototype-banner'>
+  <div class='wrapper'>
     <h2>Experimental prototype. Expect errors, inconsistencies and inaccuracies. <a href="http://importexportproject.tumblr.com" rel="external">Give feedback on the prototype</a>.</h2>
   </div>
 </header>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,8 +19,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:image" content="https://assets.digital.cabinet-office.gov.uk/static/opengraph-image-a1f7d89ffd0782738b1aeb0da37842d8bd0addbd724b8e58c3edbc7287cc11de.png">
 
-  <link rel='stylesheet' media="screen" href="{{ "/css/prototype.css" | prepend: site.baseurl }}">
-
   {% if page.layout == 'topic' %}
     <link rel="stylesheet" media="screen" href="{{ "/css/static.css" | prepend: site.baseurl }}">
     <link rel="stylesheet" media="print" href="{{ "/css/static-print.css" | prepend: site.baseurl }}">
@@ -41,6 +39,8 @@
     <link rel="stylesheet" media="print" href="{{ "/css/static-print.css" | prepend: site.baseurl }}">
     <link rel="stylesheet" media="screen" href="{{ "/css/guide.css" | prepend: site.baseurl }}">
   {% endif %}
+
+  <link rel='stylesheet' media="screen" href="{{ "/css/prototype.css" | prepend: site.baseurl }}">
 
   <link title="Search" rel="search" type="application/opensearchdescription+xml" href="https://www.gov.uk/search/opensearch.xml">
 </head>

--- a/css/prototype.css
+++ b/css/prototype.css
@@ -1,16 +1,40 @@
 #prototype-banner {
-  padding: 10px 0 5px;
-  color: #fff;
-  font-size: 18px;
-  font-weight: bold;
   background: #005ea5;
+  border-bottom: none;
+  color: #fff;
+  padding: 15px 0;
 }
 
-#prototype-banner a {
+#prototype-banner .wrapper {
+  max-width: 960px;
+  margin: 0 30px;
+}
+
+@media (min-width: 641px) {
+  #prototype-banner .wrapper {
+    margin: 0 20px;
+  }
+}
+
+@media (min-width: 1020px) {
+  #prototype-banner .wrapper {
+    margin: 0 auto;
+  }
+}
+
+#prototype-banner .wrapper h2 {
+  font-size: 18px;
+  font-weight: normal;
+  line-height: 1.25em;
+  margin-bottom: 0;
+  margin-top: 0;
+}
+
+#prototype-banner .wrapper h2 a {
   color: #fff;
 }
 
-#prototype-banner a[rel="external"]:after {
+#prototype-banner ..wrapper h2 a[rel="external"]:after {
   color: #fff !important;
   background-position-y: 4px;
 }


### PR DESCRIPTION
Remove publishing specific styles from prototype banner and use a custom
one so it renders the same way on each format type
