### PR TITLE
Fixes psycho rb template error

### DIFF
--- a/guide/move-goods-eu/make-declaration.markdown
+++ b/guide/move-goods-eu/make-declaration.markdown
@@ -1,6 +1,6 @@
 ---
 layout: guide
-title: Moving goods in the EU: when to make declarations  
+title: "Moving goods in the EU: when to make declarations"
 permalink: /guide/move-goods-eu/make-declaration.html
 page_number: 2
 page_title: Make a community transit declaration through NCTS

--- a/guide/move-goods-eu/special-territories.markdown
+++ b/guide/move-goods-eu/special-territories.markdown
@@ -1,6 +1,6 @@
 ---
 layout: guide
-title: Moving goods in the EU: when to make declarations
+title: "Moving goods in the EU: when to make declarations"
 permalink: /guide/move-goods-eu/special-territories.html
 page_number: 3
 page_title: Channel Islands, EU special territories, Andorra and San Marino


### PR DESCRIPTION
The Heroku app was not working properly, I had a look at the logs and there were issues with the format of the templates (they would need double quotes within the title)

This PR fixes the issue by adding quotes to the title.

``` shell
Configuration file: /Users/pmanrubia/work/govuk-import-export-prototype/_config.yml
            Source: /Users/pmanrubia/work/govuk-import-export-prototype
       Destination: /Users/pmanrubia/work/govuk-import-export-prototype/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
Error reading file /Users/pmanrubia/work/govuk-import-export-prototype/guide/move-goods-eu/make-declaration.markdown: (<unknown>): mapping values are not allowed in this context at line 3 column 30
Error reading file /Users/pmanrubia/work/govuk-import-export-prototype/guide/move-goods-eu/special-territories.markdown: (<unknown>): mapping values are not allowed in this context at line 3 column 30
  Liquid Exception: (<unknown>): mapping values are not allowed in this context at line 3 column 30 in _layouts/guide.html
jekyll 3.1.2 | Error:  (<unknown>): mapping values are not allowed in this context at line 3 column 30
```
## Note:

I am ignoring the build errors as this PR is not introducing any new failures.
