### PR TITLE
Prevent browsers from caching information

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,6 +19,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:image" content="https://assets.digital.cabinet-office.gov.uk/static/opengraph-image-a1f7d89ffd0782738b1aeb0da37842d8bd0addbd724b8e58c3edbc7287cc11de.png">
 
+  {% include no_cache.html %}
+
   {% if page.layout == 'topic' %}
     <link rel="stylesheet" media="screen" href="{{ "/css/topic/static.css" | prepend: site.baseurl }}">
     <link rel="stylesheet" media="print"  href="{{ "/css/topic/static-print.css" | prepend: site.baseurl }}">

--- a/_includes/no_cache.html
+++ b/_includes/no_cache.html
@@ -1,0 +1,5 @@
+<meta http-equiv="cache-control" content="max-age=0" />
+<meta http-equiv="cache-control" content="no-cache" />
+<meta http-equiv="expires" content="0" />
+<meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
+<meta http-equiv="pragma" content="no-cache" />


### PR DESCRIPTION
Users had issues with showing old data after an update. We have investigated the issue and the only place where data is being cached is the browser.

This PR adds some HTML tags to prevent caching in the browser.
Not all tags are necessary for modern browsers, but all of them are added for compatibility reasons.

``` html
<meta http-equiv="cache-control" content="max-age=0" />
<meta http-equiv="cache-control" content="no-cache" />
<meta http-equiv="expires" content="0" />
<meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
<meta http-equiv="pragma" content="no-cache" />
```
